### PR TITLE
Tightening Up Intro (2)

### DIFF
--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -91,7 +91,7 @@ and will use placeholders until these are released.]
 
 Kyber is a key-encapsulation mechanism (KEM) standardized by the US NIST
 PQC Project {{PQCProj}}. This document specifies the use of the Kyber
-algorithm at three security levels, Kyber512, Kyber768, and Kyber1024,
+algorithm at three security levels: Kyber512, Kyber768, and Kyber1024,
 in X.509 public key certificates; see {{!RFC5280}}. Public and private
 key encodings are also specified.
 

--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -41,15 +41,24 @@ author:
     email: bas@westerbaan.name
 
 normative:
+  X.680:
+    target: https://www.itu.int/rec/T-REC-X.680
+    title: "Information technology - Abstract Syntax Notation One (ASN.1): Specification of basic notation"
+    date: Feburary 2021
+    author:
+      org: ITU-T
+      seriesinfo:
+        ISO/IEC: 8824-1:2021
+  X.690:
+    target: https://www.itu.int/rec/T-REC-X.690
+    title: "Information technology - Abstract Syntax Notation One (ASN.1): ASN.1 encoding rules: Specification of Basic Encoding Rules (BER), Canonical Encoding Rules (CER) and Distinguished Encoding Rules (DER)"
+    date: Feburary 2021
+    author:
+      org: ITU-T
+      seriesinfo:
+        ISO/IEC: 8825-1:2021
 
 informative:
-  PQCProj:
-    target: https://csrc.nist.gov/projects/post-quantum-cryptography
-    title: Post-Quantum Cryptography Project
-    author:
-      - org: National Institute of Standards and Technology
-    date: 2016-12-20
-
 
 --- abstract
 
@@ -74,24 +83,26 @@ and will use placeholders until these are released.]
 
 # Introduction
 
-The US NIST PQC Project has selected the Kyber algorithm
-as winner of their PQC Project {{PQCProj}}. This
-algorithm is a Key Encapsulation Mechanism(KEM). NIST has also defined object identifiers
-for these algorithms (TODO insert reference).
+Kyber is a key-encapasulation mechanism (KEM). This document specifies
+the use of the Kyber algorithm at three security levels, Kyber512,
+Kyber768, and Kyber1024, in X.509 public key certifiates; see
+{{!RFC5280}}. Public and private key encodings are alsospecified.
 
-This document specifies the use of the Kyber algorithm
-in X.509 public key certifiates, see {{!RFC5280}}.
-It also specifies private key encoding.
-An ASN.1 module is included for reference purposes.
+## ASN.1 and Kyber Identifiers
 
-These certificates could be used as Issuers in CMS where the public key
-is used to encapsulate a shared secret used to derive a symmetric key
-used to encrypt content in CMS
-\[EDNOTE: Add reference draft-perret-prat-lamps-cms-pq-kem\].
-To be used in TLS, these certificates could only be used as end-entity
-identity certificates and would require significant updates to the
-protocol
-\[EDNOTE: Add reference draft-celi-wiggers-tls-authkem\].
+An ASN.1 module {{X680}} is included for reference purposes. Note that
+as per {{RFC5280}}, certificates use the Distinguished Encoding Rules;
+see {{X690}}. Also note that NIST defined the object identifiers for
+the Kyber algorithms in an ASN.1 modulle; see (TODO insert reference).
+
+## Applicability Statement
+
+Kyber certificates are used in protocols where the public key is used to
+encapsulate a shared secret used to derive a symmetric key used to
+encrypt a payload; see {{?I-D.ietf-lamps-kyber}}. To be used in
+TLS, Kyber certificates could only be used as end-entity identity
+certificates and would require significant updates to the protocol; see
+{{?I-D.celi-wiggers-tls-authkem}}.
 
 # Conventions and Definitions
 

--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -105,7 +105,7 @@ the Kyber algorithms in an ASN.1 modulle; see (TODO insert reference).
 ## Applicability Statement
 
 Kyber certificates are used in protocols where the public key is used to
-encapsulate a shared secret used to derive a symmetric key used to
+generate and encapsulate a shared secret used to derive a symmetric key used to
 encrypt a payload; see {{?I-D.ietf-lamps-kyber}}. To be used in
 TLS, Kyber certificates could only be used as end-entity identity
 certificates and would require significant updates to the protocol; see

--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -55,7 +55,7 @@ normative:
     date: Feburary 2021
     author:
       org: ITU-T
-      seriesinfo:
+    seriesinfo:
         ISO/IEC: 8825-1:2021
 
 informative:

--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -59,6 +59,12 @@ normative:
         ISO/IEC: 8825-1:2021
 
 informative:
+  PQCProj:
+    target: https://csrc.nist.gov/projects/post-quantum-cryptography
+    title: Post-Quantum Cryptography Project
+    author:
+      - org: National Institute of Standards and Technology
+    date: 2016-12-20
 
 --- abstract
 

--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -47,7 +47,7 @@ normative:
     date: Feburary 2021
     author:
       org: ITU-T
-      seriesinfo:
+    seriesinfo:
         ISO/IEC: 8824-1:2021
   X.690:
     target: https://www.itu.int/rec/T-REC-X.690

--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -49,7 +49,7 @@ normative:
       org: ITU-T
     seriesinfo:
         ISO/IEC: 8824-1:2021
-  X.690:
+  X690:
     target: https://www.itu.int/rec/T-REC-X.690
     title: "Information technology - Abstract Syntax Notation One (ASN.1): ASN.1 encoding rules: Specification of Basic Encoding Rules (BER), Canonical Encoding Rules (CER) and Distinguished Encoding Rules (DER)"
     date: Feburary 2021

--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -41,7 +41,7 @@ author:
     email: bas@westerbaan.name
 
 normative:
-  X.680:
+  X680:
     target: https://www.itu.int/rec/T-REC-X.680
     title: "Information technology - Abstract Syntax Notation One (ASN.1): Specification of basic notation"
     date: Feburary 2021

--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -89,10 +89,11 @@ and will use placeholders until these are released.]
 
 # Introduction
 
-Kyber is a key-encapasulation mechanism (KEM). This document specifies
-the use of the Kyber algorithm at three security levels, Kyber512,
-Kyber768, and Kyber1024, in X.509 public key certifiates; see
-{{!RFC5280}}. Public and private key encodings are alsospecified.
+Kyber is a key-encapsulation mechanism (KEM) standardized by the US NIST
+PQC Project {{PQCProj}}. This document specifies the use of the Kyber
+algorithm at three security levels, Kyber512, Kyber768, and Kyber1024,
+in X.509 public key certificates; see {{!RFC5280}}. Public and private
+key encodings are also specified.
 
 ## ASN.1 and Kyber Identifiers
 

--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -196,7 +196,7 @@ textual encoding defined in {{?RFC7468}}.
 # Key Usage Bits
 
 The intended application for the key is indicated in the keyUsage
-certificate extension; see {{See Section 4.2.1.3 of RFC5280}}.
+certificate extension; see {{Section 4.2.1.3 of RFC5280}}.
 
 If the keyUsage extension is present in a certificate that indicates
 Kyber TBD1 in SubjectPublicKeyInfo, then the following

--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -196,7 +196,7 @@ textual encoding defined in {{?RFC7468}}.
 # Key Usage Bits
 
 The intended application for the key is indicated in the keyUsage
-certificate extension; see [RFC5280, section 4.2.1.3].
+certificate extension; see {{See Section 4.2.1.3 of RFC5280}}.
 
 If the keyUsage extension is present in a certificate that indicates
 Kyber TBD1 in SubjectPublicKeyInfo, then the following


### PR DESCRIPTION
This takes a slightly different slant by:
- removing reference to NIST PQ Project - some might not care and implement it regardless
- pretty sure the Kyber OIDs are going in ASN.1 module  that will be referenced [here](https://csrc.nist.gov/Projects/Computer-Security-Objects-Register/algorithm-registration#Modules)
- We can be explicit about the applicability by putting it in a sub-section.

Note: Also see #25, which is an alternative intro.