### PR TITLE
Fix private key pretty print

### DIFF
--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -483,62 +483,62 @@ key in the previous section.
 ~~~
 
 ~~~
-0  818: SEQUENCE {
-4   11:   SEQUENCE {
-6    9:     OBJECT IDENTIFIER '2.16.840.1.101.3.4.4.1'
-      :     }
-17 801:   BIT STRING
-      :     00 39 95 81 5e 59 7d 10 43 55 cf 29 aa 53 33 c9
-      :     32 51 86 9d 5b cd be 48 71 24 f6 02 b8 b6 a6 6c
-      :     7f 0a c0 76 b0 c6 2e fa 32 81 53 e7 ca 57 01 69
-      :     9f 13 05 f1 e6 bc 6f 90 b0 e4 9b 69 35 12 b6 ce
-      :     99 2a 8b 80 16 dd fc 1a 66 2c 7e 3f 96 19 cb d8
-      :     69 dd 77 1a f3 08 96 cc d5 91 8a c6 cb 77 46 6c
-      :     5e 77 99 96 d6 7f f9 aa bc 97 50 3f 2c 7b 7e 2d
-      :     00 0d 86 45 0f b1 80 7c a4 ca bd a4 65 82 5a 31
-      :     c7 89 a1 b7 a4 91 ab 38 72 76 5d 32 0d 0b 71 92
-      :     0f a2 13 c9 40 93 41 6b 83 b8 12 4e 69 f6 5e 62
-      :     cb 50 00 dc c3 7a a9 a0 ff f7 39 70 c4 77 2f 35
-      :     7d 24 18 9c a6 f5 30 55 68 c0 e2 37 6a 37 62 a6
-      :     8c 60 5e 56 3c 5d 20 95 72 e0 fc 75 32 ca 29 47
-      :     29 53 55 67 b5 fc 41 3c 5e 87 92 d2 46 45 36 cc
-      :     80 8f 98 ad d7 46 64 f1 41 56 6f 90 16 a9 0a 54
-      :     18 29 a9 8a 04 64 ce 41 a8 bb 44 c2 d4 fa 3c 2c
-      :     20 94 60 72 8e f1 4a 1a 7c 4c 9b 98 d1 22 03 b4
-      :     cc 35 29 16 0a 9a b2 d7 83 8f 7f f6 b5 3a e0 5a
-      :     a3 1a 7d 64 6b 7a fa 6c 45 93 25 26 a3 c3 75 56
-      :     19 be 99 4c 21 1c 2a 31 c0 5b 34 47 83 6c b2 15
-      :     0b e1 82 9d ae 6b 04 c5 53 5c ff 54 6e 39 2b a7
-      :     97 41 17 20 f9 24 f4 90 a5 ac 54 95 f2 13 56 d5
-      :     50 b7 82 a6 4c 16 88 b6 b6 55 bc c7 84 21 97 a4
-      :     34 c2 f6 56 3b 5b 7f 09 a7 8b cc 48 82 32 78 35
-      :     61 d1 6f 4c ba b6 75 54 00 05 07 81 57 0c 66 60
-      :     4b 81 7a d1 25 22 94 73 6e 8b 01 86 1a 4b 5a 74
-      :     51 9b 8b 6f e5 14 89 a5 07 23 92 e5 87 62 6c 71
-      :     37 76 57 5d 33 80 6a 1c 8e 27 32 af 97 c2 68 0f
-      :     51 66 63 31 c4 eb 8b bc 04 31 c4 f9 68 32 da f1
-      :     b3 c4 55 28 fb a1 53 f6 c7 8b 1c 19 87 02 94 7c
-      :     cd 33 77 27 a4 6f b5 3b a1 1d e5 cb 41 91 34 68
-      :     59 51 6c b6 ad 72 40 0f 3c f2 09 b2 36 ae f3 5a
-      :     58 0a c8 7e b3 e3 0f af d6 69 73 ca 8a 7d d2 67
-      :     5a f4 1f 7a 17 b6 14 33 cd 1a f8 0f 77 08 86 9f
-      :     66 54 88 49 79 80 b1 ac 10 a0 cd cb 63 6a 00 ed
-      :     86 81 b3 5e 42 91 24 ca 80 35 07 25 b8 5f 83 a5
-      :     ea c3 a4 a3 cc 16 00 90 3e 65 29 35 60 b9 b3 36
-      :     e5 af 0d 52 9d ac 1a 04 81 19 30 2c b7 a9 bc c1
-      :     10 b9 48 51 bf 02 11 7f 19 9d c4 85 a8 52 b7 47
-      :     3f 09 b8 31 a6 83 1d 5b 54 c0 b7 90 d2 25 cf 6b
-      :     b9 2d 94 62 a2 6c db 33 dd a5 12 3c 7a af 0e 26
-      :     a0 b8 36 55 ee a2 8b f3 a8 07 47 25 01 8f d6 ba
-      :     e4 b6 01 cf 61 ba ab 71 a7 a3 d3 51 97 a3 43 e7
-      :     4b 4a 27 2c 12 5d 54 08 96 42 6d 85 b7 95 8d 3b
-      :     38 a6 ba 98 7e c3 72 25 c7 b4 4c db 12 dd e4 53
-      :     9b 4a b0 82 36 36 83 f0 4b f7 a0 9c c5 c4 1d fe
-      :     83 0a 1b 16 2e 0b 32 43 34 36 2f 08 4a 14 46 77
-      :     23 34 4b ad d0 00 f8 d8 c5 37 c4 8f 99 8f 05 30
-      :     7c eb d1 ed e0 b8 1c 3b c5 9a 06 5a 1b 6d 63 b2
-      :     6c
-      :   }
+  0 818: SEQUENCE {
+  4  11:   SEQUENCE {
+  6   9:     OBJECT IDENTIFIER '2 16 840 1 101 3 4 4 1'
+       :     }
+ 17 801:   BIT STRING
+       :     39 95 81 5E 59 7D 10 43 55 CF 29 AA 53 33 C9 32
+       :     51 86 9D 5B CD BE 48 71 24 F6 02 B8 B6 A6 6C 16
+       :     C4 76 16 48 AD 76 5C F5 D8 00 6B 51 5E 90 5A 7F
+       :     0A C0 76 B0 C6 2E FA 32 81 53 E7 CA 57 01 69 9F
+       :     13 05 F1 E6 BC 6F 90 B0 E4 9B 69 35 12 B6 CE 99
+       :     2A 8B 80 16 DD FC 1A 66 2C 7E 3F 96 19 CB D8 69
+       :     DD 77 1A F3 08 96 CC D5 91 8A C6 CB 77 46 6C 5E
+       :     77 99 96 D6 7F F9 AA BC 97 50 3F 2C 7B 7E 2D 00
+       :     0D 86 45 0F B1 80 7C A4 CA BD A4 65 82 5A 31 C7
+       :     89 A1 B7 A4 91 AB 38 72 76 5D 32 0D 0B 71 92 0F
+       :     A2 13 C9 40 93 41 6B 83 B8 12 4E 69 F6 5E 62 CB
+       :     50 00 DC C3 7A A9 A0 FF F7 39 70 C4 77 2F 35 7D
+       :     24 18 9C A6 F5 30 55 68 C0 E2 37 6A 37 62 A6 8C
+       :     60 5E 56 3C 5D 20 95 72 E0 FC 75 32 CA 29 47 29
+       :     53 55 67 B5 FC 41 3C 5E 87 92 D2 46 45 36 CC 80
+       :     8F 98 AD D7 46 64 F1 41 56 6F 90 16 A9 0A 54 18
+       :     29 A9 8A 04 64 CE 41 A8 BB 44 C2 D4 FA 3C 2C 20
+       :     94 60 72 8E F1 4A 1A 7C 4C 9B 98 D1 22 03 B4 CC
+       :     35 29 16 0A 9A B2 D7 83 8F 7F F6 B5 3A E0 5A A3
+       :     1A 7D 64 6B 7A FA 6C 45 93 25 26 A3 C3 75 56 19
+       :     BE 99 4C 21 1C 2A 31 C0 5B 34 47 83 6C B2 15 0B
+       :     E1 82 9D AE 6B 04 C5 53 5C FF 54 6E 39 2B A7 97
+       :     41 17 20 F9 24 F4 90 A5 AC 54 95 F2 13 56 D5 50
+       :     B7 82 A6 4C 16 88 B6 B6 55 BC C7 84 21 97 A4 34
+       :     C2 F6 56 3B 5B 7F 09 A7 8B CC 48 82 32 78 35 61
+       :     D1 6F 4C BA B6 75 54 00 05 07 81 57 0C 66 60 4B
+       :     81 7A D1 25 22 94 73 6E 8B 01 86 1A 4B 5A 74 51
+       :     9B 8B 6F E5 14 89 A5 07 23 92 E5 87 62 6C 71 37
+       :     76 57 5D 33 80 6A 1C 8E 27 32 AF 97 C2 68 0F 51
+       :     66 63 31 C4 EB 8B BC 04 31 C4 F9 68 32 DA F1 B3
+       :     C4 55 28 FB A1 53 F6 C7 8B 1C 19 87 02 94 7C CD
+       :     33 77 27 A4 6F B5 3B A1 1D E5 CB 41 91 34 68 59
+       :     51 6C B6 AD 72 40 0F 3C F2 09 B2 36 AE F3 5A 58
+       :     0A C8 7E B3 E3 0F AF D6 69 73 CA 8A 7D D2 67 5A
+       :     F4 1F 7A 17 B6 14 33 CD 1A F8 0F 77 08 86 9F 66
+       :     54 88 49 79 80 B1 AC 10 A0 CD CB 63 6A 00 ED 86
+       :     81 B3 5E 42 91 24 CA 80 35 07 25 B8 5F 83 A5 EA
+       :     C3 A4 A3 CC 16 00 90 3E 65 29 35 60 B9 B3 36 E5
+       :     AF 0D 52 9D AC 1A 04 81 19 30 2C B7 A9 BC C1 10
+       :     B9 48 51 BF 02 11 7F 19 9D C4 85 A8 52 B7 47 3F
+       :     09 B8 31 A6 83 1D 5B 54 C0 B7 90 D2 25 CF 6B B9
+       :     2D 94 62 A2 6C DB 33 DD A5 12 3C 7A AF 0E 26 A0
+       :     B8 36 55 EE A2 8B F3 A8 07 47 25 01 8F D6 BA E4
+       :     B6 01 CF 61 BA AB 71 A7 A3 D3 51 97 A3 43 E7 4B
+       :     4A 27 2C 12 5D 54 08 96 42 6D 85 B7 95 8D 3B 38
+       :     A6 BA 98 7E C3 72 25 C7 B4 4C DB 12 DD E4 53 9B
+       :     4A B0 82 36 36 83 F0 4B F7 A0 9C C5 C4 1D FE 83
+       :     0A 1B 16 2E 0B 32 43 34 36 2F 08 4A 14 46 77 23
+       :     34 4B AD D0 00 F8 D8 C5 37 C4 8F 99 8F 05 30 7C
+       :     EB D1 ED E0 B8 1C 3B C5 9A 06 5A 1B 6D 63 B2 6C
+       :   }
 ~~~
 
 The following is the ML-KEM-768 public key corresponding to the private
@@ -549,87 +549,86 @@ key in the previous section.
 ~~~
 
 ~~~
-0 1202: SEQUENCE {
-4   11:   SEQUENCE {
-6    9:     OBJECT IDENTIFIER '2.16.840.1.101.3.4.4.2'
-      :     }
-17 801:   BIT STRING
-      :     00 29 8a a1 0d 42 3c 8d da 06 9d 02 bc 59 e6 cd
-      :     f0 3a 09 6b 8b 3d a4 ca b9 b8 0c a4 a1 49 07 67
-      :     2c ce f1 ec 4f af 23 4a 0b c5 b7 e9 d4 73 f2 b3
-      :     13 3b 3b 26 a1 d1 75 cb 67 a7 80 59 19 69 9c 02
-      :     f7 65 31 b9 9c 5f 89 18 07 04 bb 4c a4 53 5c 5b
-      :     89 72 67 9c 66 0a 07 c5 e5 14 b8 70 09 c8 62 eb
-      :     8f 51 57 69 5e fb 3f c4 0a 9d ef 6b 81 c1 cc 02
-      :     a2 49 ae 4f 09 4a d0 d9 bd 34 85 c1 c1 c6 80 80
-      :     52 0a 7c 8c 63 20 32 ce e7 38 15 4e 5c 51 76 c0
-      :     7d a5 60 24 77 6a 43 0f e7 6e ac f6 65 a3 f7 b8
-      :     32 10 22 15 bc 82 f1 09 39 c8 35 57 04 33 6a 8f
-      :     ac 1d 81 e4 bb 04 85 aa 5d 7c 74 d6 b5 9b be 5c
-      :     5e 97 2a 0d 8b ac 41 1b 55 b5 d5 55 7c d6 80 a1
-      :     a8 f7 1b 4e b8 6b c4 8c 9a 05 09 73 1a 54 bd 9d
-      :     72 90 b2 79 63 e4 37 2d c9 b1 99 cf dc ac 0b 01
-      :     ac d2 8a 62 39 51 12 e4 c4 36 48 d6 22 c4 8c 82
-      :     34 d0 14 40 e8 cc 37 6c 92 7f 23 a5 af c9 ac 04
-      :     74 c6 62 27 4e 42 45 25 c8 55 2e ce 3b 3f e2 65
-      :     16 de 90 1b c7 d5 15 bd e8 95 58 e6 26 c9 5c 80
-      :     b9 33 42 f8 01 00 04 f3 9e 6c 6c 94 87 1c 5e 34
-      :     4c ab 39 66 c8 35 f9 a9 6a 59 af d3 1c 40 28 6b
-      :     38 b1 c1 a7 84 70 ba b9 47 51 89 34 45 3c e8 67
-      :     36 a9 19 f1 f5 a6 d5 10 a8 6f 54 54 fc 39 80 cb
-      :     5c 76 5b d2 bd 5f 7b 36 b1 41 0d 66 35 c8 ce b4
-      :     7c 4d da 0d 76 a2 8e ac 93 9c 71 c3 02 48 04 86
-      :     6c 71 62 66 58 44 21 63 c2 c2 21 17 e5 0a ce fc
-      :     e6 37 8a 98 56 52 30 2a 4e f0 c2 ce 0c c7 16 b7
-      :     79 6e 2b 6b 2e 37 77 df a1 ac 3d a2 59 a3 1b 5a
-      :     9b 53 0f 8c b6 38 a8 1a 62 ac 30 18 49 ab af 95
-      :     a7 30 1b da 30 06 89 09 bf db 7e 67 db cc bb 38
-      :     a5 55 1a 25 b1 a3 a0 f6 85 74 8a d5 75 3d 88 80
-      :     f0 01 6c 62 74 86 16 63 84 c5 57 1f e2 36 59 00
-      :     36 4d 03 83 11 e2 d8 75 db 36 66 86 93 2b 5e c6
-      :     02 43 0a 36 9e 87 a6 ef 5c 33 87 86 65 78 25 bd
-      :     4c 05 7a ce b9 23 eb 09 35 e6 90 5e 63 b4 ce d7
-      :     f8 08 57 a7 73 dd 64 b1 50 d2 66 12 ea 9a c1 20
-      :     52 db 20 17 bf 18 43 cc b4 b3 28 1b 69 0d c7 28
-      :     ad fa 85 c0 02 81 b8 e3 c0 92 87 33 5f 85 6b 4f
-      :     c2 89 2f 69 a2 f5 79 21 ad a0 19 14 c4 09 88 66
-      :     2d 57 76 96 62 a7 86 35 1b 9b 66 49 3d ab 79 59
-      :     4d 98 6d e2 10 0d 65 ba 0f f4 ea 58 b8 15 38 d2
-      :     4a 44 35 a2 58 fa c2 54 04 aa 7f 41 f6 58 b1 38
-      :     50 65 e1 58 dc b6 01 15 73 27 20 f4 04 59 aa ac
-      :     15 e4 06 95 3a 90 ac 52 99 7d 1c cd 07 00 60 ef
-      :     c6 5d b9 e6 53 35 44 67 fa d5 6e c7 13 c8 6e 75
-      :     40 c4 23 ac f2 66 9f 52 fa 6f 4a c6 88 8d 87 1e
-      :     f3 e8 47 c0 29 a8 aa fb b9 2e 17 b2 4a a0 79 b1
-      :     f4 19 ba 61 75 b4 42 af b1 19 09 d4 a5 6b 70 a0
-      :     33 5b 28 73 92 18 aa 7c 93 48 e2 c3 c2 f3 eb 3d
-      :     15 a4 1e 64 17 c0 dd 94 bf eb 21 41 9b 31 1a 7b
-      :     b1 3a 18 0b be 83 32 18 a9 a6 b1 74 47 cc 85 f2
-      :     25 85 95 87 a7 30 77 04 9a cb cf d4 4d 0f 02 54
-      :     38 e1 5d 15 38 27 0d 58 6e 1b f8 31 92 a9 45 9c
-      :     f6 3c 0e 97 2f 85 29 76 79 83 1e cf 12 15 09 85
-      :     1c b8 34 0f 6f 10 7b 0f a1 a0 ef d1 b3 6a 81 89
-      :     bc 08 5c 4f 5c b7 84 e5 53 f4 1b 91 8f 80 39 7c
-      :     e1 95 6f 78 5b ee 37 7c a9 aa 8b e6 99 8a da 30
-      :     c2 6b 7c 3d 8c 6b 55 25 4c c9 62 03 b2 0c 42 ae
-      :     e0 ac 4e 1e bb 40 8e 49 a9 e3 f8 79 d0 ab 07 85
-      :     eb 70 25 42 5d 13 05 a2 29 9c 01 5e 12 0d 16 3b
-      :     0e 19 49 4c e5 72 53 d0 24 6d 18 27 45 cb 81 97
-      :     ab 74 38 b3 c1 bb 79 72 be c5 a3 06 eb a3 56 78
-      :     55 c0 14 69 9f ef 65 ae 54 c7 70 a0 d8 5c 18 40
-      :     0c f6 42 ae dc 66 07 77 ba 4b 13 85 02 bd 5a 78
-      :     12 f6 21 f8 4a 48 29 6b 98 dd 43 22 b6 f1 58 28
-      :     b8 a8 f0 e0 0a 8b a4 4a 53 c3 a8 b1 43 57 1b 07
-      :     40 ab d5 67 da f1 cd e9 c7 9c 20 4b 6d 5e 25 9d
-      :     17 66 a3 1b bb cb 4e 6a 05 cf 45 02 17 6b 30 1c
-      :     1c 2f 41 24 77 50 15 7b ce c8 5e 80 9b 30 a4 d6
-      :     0d 77 47 cd d0 f5 b9 9a a8 c8 26 98 75 17 79 3a
-      :     aa 80 80 a0 b1 24 a8 55 8d f7 2b be 37 b7 5f 4e
-      :     db b6 be 82 16 d6 c6 33 fb 2b 22 80 e2 51 13 d8
-      :     69 5e 43 48 1c 3e eb 39 7e b1 92 50 52 29 b6 7a
-      :     20 1e a8 93 c3 e2 cb 32 da 8b c3 42 fa 4d ea 05
-      :     78
-      :   }
+   0 1202: SEQUENCE {
+   4   11:   SEQUENCE {
+   6    9:     OBJECT IDENTIFIER '2 16 840 1 101 3 4 4 2'
+         :     }
+  17 1185:   BIT STRING
+         :     29 8A A1 0D 42 3C 8D DA 06 9D 02 BC 59 E6 CD F0
+         :     3A 09 6B 8B 3D A4 CA B9 B8 0C A4 A1 49 07 67 2C
+         :     CE F1 EC 4F AF 23 4A 0B C5 B7 E9 D4 73 F2 B3 13
+         :     3B 3B 26 A1 D1 75 CB 67 A7 80 59 19 69 9C 02 F7
+         :     65 31 B9 9C 5F 89 18 07 04 BB 4C A4 53 5C 5B 89
+         :     72 67 9C 66 0A 07 C5 E5 14 B8 70 09 C8 62 EB 8F
+         :     51 57 69 5E FB 3F C4 0A 9D EF 6B 81 C1 CC 02 A2
+         :     49 AE 4F 09 4A D0 D9 BD 34 85 C1 C1 C6 80 80 52
+         :     0A 7C 8C 63 20 32 CE E7 38 15 4E 5C 51 76 C0 7D
+         :     A5 60 24 77 6A 43 0F E7 6E AC F6 65 A3 F7 B8 32
+         :     10 22 15 BC 82 F1 09 39 C8 35 57 04 33 6A 8F AC
+         :     1D 81 E4 BB 04 85 AA 5D 7C 74 D6 B5 9B BE 5C 5E
+         :     97 2A 0D 8B AC 41 1B 55 B5 D5 55 7C D6 80 A1 A8
+         :     F7 1B 4E B8 6B C4 8C 9A 05 09 73 1A 54 BD 9D 72
+         :     90 B2 79 63 E4 37 2D C9 B1 99 CF DC AC 0B 01 AC
+         :     D2 8A 62 39 51 12 E4 C4 36 48 D6 22 C4 8C 82 34
+         :     D0 14 40 E8 CC 37 6C 92 7F 23 A5 AF C9 AC 04 74
+         :     C6 62 27 4E 42 45 25 C8 55 2E CE 3B 3F E2 65 16
+         :     DE 90 1B C7 D5 15 BD E8 95 58 E6 26 C9 5C 80 B9
+         :     33 42 F8 01 00 04 F3 9E 6C 6C 94 87 1C 5E 34 4C
+         :     AB 39 66 C8 35 F9 A9 6A 59 AF D3 1C 40 28 6B 38
+         :     B1 C1 A7 84 70 BA B9 47 51 89 34 45 3C E8 67 36
+         :     A9 19 F1 F5 A6 D5 10 A8 6F 54 54 FC 39 80 CB 5C
+         :     76 5B D2 BD 5F 7B 36 B1 41 0D 66 35 C8 CE B4 7C
+         :     4D DA 0D 76 A2 8E AC 93 9C 71 C3 02 48 04 86 6C
+         :     71 62 66 58 44 21 63 C2 C2 21 17 E5 0A CE FC E6
+         :     37 8A 98 56 52 30 2A 4E F0 C2 CE 0C C7 16 B7 79
+         :     6E 2B 6B 2E 37 77 DF A1 AC 3D A2 59 A3 1B 5A 9B
+         :     53 0F 8C B6 38 A8 1A 62 AC 30 18 49 AB AF 95 A7
+         :     30 1B DA 30 06 89 09 BF DB 7E 67 DB CC BB 38 A5
+         :     55 1A 25 B1 A3 A0 F6 85 74 8A D5 75 3D 88 80 F0
+         :     01 6C 62 74 86 16 63 84 C5 57 1F E2 36 59 00 36
+         :     4D 03 83 11 E2 D8 75 DB 36 66 86 93 2B 5E C6 02
+         :     43 0A 36 9E 87 A6 EF 5C 33 87 86 65 78 25 BD 4C
+         :     05 7A CE B9 23 EB 09 35 E6 90 5E 63 B4 CE D7 F8
+         :     08 57 A7 73 DD 64 B1 50 D2 66 12 EA 9A C1 20 52
+         :     DB 20 17 BF 18 43 CC B4 B3 28 1B 69 0D C7 28 AD
+         :     FA 85 C0 02 81 B8 E3 C0 92 87 33 5F 85 6B 4F C2
+         :     89 2F 69 A2 F5 79 21 AD A0 19 14 C4 09 88 66 2D
+         :     57 76 96 62 A7 86 35 1B 9B 66 49 3D AB 79 59 4D
+         :     98 6D E2 10 0D 65 BA 0F F4 EA 58 B8 15 38 D2 4A
+         :     44 35 A2 58 FA C2 54 04 AA 7F 41 F6 58 B1 38 50
+         :     65 E1 58 DC B6 01 15 73 27 20 F4 04 59 AA AC 15
+         :     E4 06 95 3A 90 AC 52 99 7D 1C CD 07 00 60 EF C6
+         :     5D B9 E6 53 35 44 67 FA D5 6E C7 13 C8 6E 75 40
+         :     C4 23 AC F2 66 9F 52 FA 6F 4A C6 88 8D 87 1E F3
+         :     E8 47 C0 29 A8 AA FB B9 2E 17 B2 4A A0 79 B1 F4
+         :     19 BA 61 75 B4 42 AF B1 19 09 D4 A5 6B 70 A0 33
+         :     5B 28 73 92 18 AA 7C 93 48 E2 C3 C2 F3 EB 3D 15
+         :     A4 1E 64 17 C0 DD 94 BF EB 21 41 9B 31 1A 7B B1
+         :     3A 18 0B BE 83 32 18 A9 A6 B1 74 47 CC 85 F2 25
+         :     85 95 87 A7 30 77 04 9A CB CF D4 4D 0F 02 54 38
+         :     E1 5D 15 38 27 0D 58 6E 1B F8 31 92 A9 45 9C F6
+         :     3C 0E 97 2F 85 29 76 79 83 1E CF 12 15 09 85 1C
+         :     B8 34 0F 6F 10 7B 0F A1 A0 EF D1 B3 6A 81 89 BC
+         :     08 5C 4F 5C B7 84 E5 53 F4 1B 91 8F 80 39 7C E1
+         :     95 6F 78 5B EE 37 7C A9 AA 8B E6 99 8A DA 30 C2
+         :     6B 7C 3D 8C 6B 55 25 4C C9 62 03 B2 0C 42 AE E0
+         :     AC 4E 1E BB 40 8E 49 A9 E3 F8 79 D0 AB 07 85 EB
+         :     70 25 42 5D 13 05 A2 29 9C 01 5E 12 0D 16 3B 0E
+         :     19 49 4C E5 72 53 D0 24 6D 18 27 45 CB 81 97 AB
+         :     74 38 B3 C1 BB 79 72 BE C5 A3 06 EB A3 56 78 55
+         :     C0 14 69 9F EF 65 AE 54 C7 70 A0 D8 5C 18 40 0C
+         :     F6 42 AE DC 66 07 77 BA 4B 13 85 02 BD 5A 78 12
+         :     F6 21 F8 4A 48 29 6B 98 DD 43 22 B6 F1 58 28 B8
+         :     A8 F0 E0 0A 8B A4 4A 53 C3 A8 B1 43 57 1B 07 40
+         :     AB D5 67 DA F1 CD E9 C7 9C 20 4B 6D 5E 25 9D 17
+         :     66 A3 1B BB CB 4E 6A 05 CF 45 02 17 6B 30 1C 1C
+         :     2F 41 24 77 50 15 7B CE C8 5E 80 9B 30 A4 D6 0D
+         :     77 47 CD D0 F5 B9 9A A8 C8 26 98 75 17 79 3A AA
+         :     80 80 A0 B1 24 A8 55 8D F7 2B BE 37 B7 5F 4E DB
+         :     B6 BE 82 16 D6 C6 33 FB 2B 22 80 E2 51 13 D8 69
+         :     5E 43 48 1C 3E EB 39 7E B1 92 50 52 29 B6 7A 20
+         :     1E A8 93 C3 E2 CB 32 DA 8B C3 42 FA 4D EA 05 78
+         :   }
 ~~~
 
 The following is the ML-KEM-1024 public key corresponding to the private
@@ -640,111 +639,110 @@ key in the previous section.
 ~~~
 
 ~~~
-0  1586: SEQUENCE {
-4    11:   SEQUENCE {
-6     9:     OBJECT IDENTIFIER '2.16.840.1.101.3.4.4.3'
-       :     }
-17 1569:   BIT STRING
-       :     00 4b 94 c2 94 50 11 11 91 82 3b 35 14 c9 ac 1e
-       :     a3 d9 82 5c cb 86 39 3a 2d fb 04 65 4f a2 19 2d
-       :     37 bf ad 1c 49 7c 65 02 ee e5 ca 80 a7 3b fc e0
-       :     ba f5 a5 4a 88 58 5a 40 13 97 a3 d2 32 f4 26 a7
-       :     af b0 82 bc 21 a4 43 17 09 0e aa c7 59 2c 2e a8
-       :     8a 65 3c 44 91 ea 19 39 31 33 5f 52 e9 89 a3 c4
-       :     cc 56 d9 c5 53 73 2d 57 c4 70 fb 41 ab 75 9b 65
-       :     d2 d0 44 45 38 2f cd 9c 4e 34 4a 11 28 fa 9e 11
-       :     e0 43 58 e1 92 ed 01 4b 23 23 2a 7e e2 b2 2e 23
-       :     71 7f 44 11 1e e3 35 75 39 9c 37 64 6d a9 81 3e
-       :     c9 b2 12 af e9 4e 5d c5 c2 33 0a 72 94 cc 1f 42
-       :     34 a6 d3 fb b4 f1 68 5a b8 89 2c 04 ac b1 7c d1
-       :     c1 70 d7 b0 61 1b 6a 71 76 c7 94 cc 8c 67 f5 5f
-       :     c9 23 c2 ad 20 31 00 f3 65 99 18 82 c3 02 43 d7
-       :     78 13 84 3b 5e c7 c9 64 03 22 63 70 60 92 ec f0
-       :     0c 75 16 be 64 e4 59 8c a4 22 6c 06 9b b5 e6 7e
-       :     41 75 cf 22 86 c8 dd 5c 48 8a 6c 58 61 f3 1b aa
-       :     0b d0 26 94 70 e8 b5 51 dd 3b cd 38 c8 6c 12 f9
-       :     cd b1 76 c7 7d c8 b6 c0 2a 70 1f 47 89 02 c8 55
-       :     3f 69 4c 0d 82 72 7b 4c 4a 5c 2c 10 41 21 2a a1
-       :     27 48 08 b8 21 11 b3 77 ec 75 21 4e 9b 19 78 f7
-       :     60 04 d4 13 9d 98 61 3f 4b 8e 98 d2 0a f7 b5 34
-       :     07 3a 50 9a 95 9b 7a 75 64 f9 b4 0c a2 18 bf 61
-       :     82 93 20 a8 50 20 17 95 4d 32 8d 7a c6 c7 69 ec
-       :     29 70 07 56 e7 b0 68 5b 34 0d 5e 11 80 59 50 4a
-       :     49 a9 a5 0a 10 19 8e b1 0a 57 84 67 8e b4 27 d7
-       :     b4 ba bb 95 52 93 3b 06 28 97 97 3e 13 18 ea f0
-       :     a0 ea c3 75 84 a6 54 01 b1 70 3e 04 2a cc d8 37
-       :     53 14 83 f2 41 ca dc d1 c1 d3 78 11 9e 69 44 29
-       :     db 19 9a c8 91 e4 c5 34 37 57 08 5b b3 ae 78 36
-       :     67 35 0c 44 58 d9 76 72 e8 61 e8 0b 1d 26 79 51
-       :     0e a3 a6 f2 36 0c 77 a4 69 42 c7 a0 6a 55 4d 22
-       :     80 80 c8 4b 47 ae f1 4d b1 76 20 cb 16 c0 6a b3
-       :     0a 1b e4 cd a7 08 2b e9 f8 7e 9c 21 1c 46 91 63
-       :     49 a5 ba 8e aa 52 01 c7 29 4a 3c 08 85 b5 3b 65
-       :     74 52 10 88 25 ec 64 6c 90 a0 46 12 32 4e e7 d0
-       :     31 af e5 34 31 32 cb ef 67 b6 ef b1 a5 ec 28 09
-       :     b7 73 53 8c e7 7b 3d 8b 04 eb 0b 3c 22 56 01 1e
-       :     4c 71 6c 19 a8 ba 07 52 bf 71 49 21 17 64 9f 06
-       :     15 c3 29 0f c2 9a 46 fd e4 bd 52 db 92 86 d6 03
-       :     38 82 44 25 9c 15 a7 ac 2b 64 0a 60 cc 03 37 6a
-       :     58 41 a3 fb 8a 47 35 68 fa 9b 1a 26 72 15 f3 4c
-       :     01 69 7b 0f 0e 62 71 75 d7 21 05 b7 70 7c 29 b9
-       :     e6 14 bd c3 3a 6f 6c 81 8a 95 37 0b 42 78 82 d7
-       :     b4 76 79 6a 9e c6 eb 99 32 74 cd 9b 23 91 a8 2b
-       :     a4 5e 33 93 d2 e9 ae 97 21 ca 9d 6c 1b 98 8b 58
-       :     27 71 3f 90 a6 58 5d e9 43 35 28 c0 2b 03 ce 10
-       :     bb 5f 72 01 38 d0 fb b4 c3 0c 12 66 b9 18 e5 29
-       :     25 df e1 7b 37 f9 5d 22 bc a5 4f 47 59 19 ac 85
-       :     90 98 c0 f0 d0 8a c5 87 5e f2 9b 56 fd 14 1e 6e
-       :     f1 5f 70 0a 0b 66 f3 95 95 c5 88 17 73 73 c4 66
-       :     9b 21 bc 07 1e 4c 3a a5 f0 b4 a3 1b 62 58 f3 5d
-       :     a2 4a c3 cd 29 c7 f2 09 24 10 c5 07 83 55 b1 38
-       :     fb 53 a6 b9 ae 6e 0b 9c 08 24 3e 7b aa 45 c4 73
-       :     76 eb 8c 7f 13 d4 cf 51 aa 73 6f a3 15 40 c9 24
-       :     1f 37 0d a5 44 bf 9f 9c 28 d9 a5 7e 2f 2a 7c a9
-       :     5a 4e 4b 46 6e 64 1a b3 bc c7 6a df 11 39 d5 67
-       :     a6 f1 2b 52 f3 a6 5e 7e c0 aa e2 6b ca a8 c5 58
-       :     33 b0 4e 59 99 8e bc 9a 19 30 fb b6 d2 23 3c 53
-       :     d2 c1 f8 b9 51 8e 3c 2d e7 3a 19 de e6 b3 80 a5
-       :     b3 29 71 cf 64 e1 29 fd 6c 1f a6 e7 5d 4a 23 45
-       :     01 e9 66 dd 3a 54 0a f5 c8 f4 f3 4a 6b 4a 25 3e
-       :     e2 84 92 56 6d 5e 67 c6 f5 58 55 fc b0 50 6f b0
-       :     6c 15 67 44 d9 a0 3a 31 a2 6f a9 4c ad 14 f1 57
-       :     b7 f3 03 d0 7a 69 c7 73 76 8f cb 4d 07 9c 09 05
-       :     97 03 a0 c3 a9 4d e4 b9 9e a3 a2 f1 65 83 d0 f9
-       :     17 0a 39 50 db 07 b4 f0 bc 30 80 29 27 f9 f7 96
-       :     1b 62 59 89 26 36 a9 50 2a 27 05 30 36 37 79 9d
-       :     d3 44 da 45 1c 1c f7 bf 67 84 0c eb 30 79 ab 8c
-       :     6b 8c 19 27 f6 40 53 c6 12 45 0c 45 c9 e6 03 bc
-       :     16 66 6e 59 6b 34 71 e1 03 b6 f1 54 47 42 4d 17
-       :     02 20 48 11 1f fb d3 7e 1c 67 0f 64 f1 4b 8a 7b
-       :     32 b9 4c 1a 49 b4 5d d2 fc 38 cd 52 89 d9 10 ad
-       :     63 60 2c f5 e1 30 42 c6 4a c6 79 7b 89 fb 55 1a
-       :     d0 8e 05 a9 2d 20 0c cc b7 e7 12 ef 23 c9 31 2c
-       :     b3 50 f0 29 ab 53 7e 28 73 47 fd 30 75 ac 10 90
-       :     6a 78 3f 1c 6c 07 cc b8 8f 41 22 8c 4b e1 c6 40
-       :     f7 90 b5 c3 a5 d5 d3 ca 79 24 95 d7 4b c4 61 56
-       :     26 58 c0 7a c6 00 27 6b 92 4a b5 bc 9b e1 f0 49
-       :     4c b7 6f 82 f4 60 a7 48 09 72 66 33 81 e1 69 99
-       :     60 61 d7 99 85 9e c5 4d 4f 5c a5 c4 11 c0 1d b1
-       :     59 7b 16 59 77 66 9d e1 3a 92 8a 34 af ba c2 58
-       :     fe a8 c4 76 42 39 c9 42 1d c3 11 9b f5 b4 76 99
-       :     20 69 78 32 7b 1c 53 45 ef 74 6a 79 83 84 1f 05
-       :     6e 25 34 10 0a b2 4d 4e 9a bb d0 b1 7c 6a 95 bd
-       :     4c 3c 0e 40 f6 9e 16 12 ac ee b2 8b 99 08 6c 95
-       :     11 6e 72 04 27 38 93 39 0b f4 6b 89 9b 36 28 6b
-       :     0e bf 19 47 bb 98 84 f7 32 ca 27 da 82 b1 9b 5d
-       :     c0 cc 7f 88 85 71 49 10 88 8b 23 10 c4 f9 31 9d
-       :     41 0b 34 e6 43 3b 90 03 e2 17 6b b9 95 25 74 56
-       :     10 6e 89 52 16 3b 8b a5 92 53 0c c5 aa 0a eb 43
-       :     ad 39 8f e9 e9 7b aa 52 3d 7a 44 31 67 7c 3d 3a
-       :     f0 71 9e 47 5d b8 5c a9 5a f5 08 9b ea be b0 5b
-       :     2f aa b4 89 6b a6 0f 81 c8 84 72 a5 7b 46 a8 28
-       :     82 6a 0c df b4 46 f8 18 91 82 d2 bf 5e ac 4e c1
-       :     cc 5d ea f5 99 c8 a1 3e 48 23 54 06 d1 7f fd dc
-       :     83 44 b6 c6 69 84 a8 68 aa 92 fa 02 22 7a 08 69
-       :     50 eb 0c 87 01 ed 58 dc 62 87 76 b9 83 88 2e 11
-       :     75
-       :   }
+   0 1586: SEQUENCE {
+   4   11:   SEQUENCE {
+   6    9:     OBJECT IDENTIFIER '2 16 840 1 101 3 4 4 3'
+         :     }
+  17 1569:   BIT STRING
+         :     4B 94 C2 94 50 11 11 91 82 3B 35 14 C9 AC 1E A3
+         :     D9 82 5C CB 86 39 3A 2D FB 04 65 4F A2 19 2D 37
+         :     BF AD 1C 49 7C 65 02 EE E5 CA 80 A7 3B FC E0 BA
+         :     F5 A5 4A 88 58 5A 40 13 97 A3 D2 32 F4 26 A7 AF
+         :     B0 82 BC 21 A4 43 17 09 0E AA C7 59 2C 2E A8 8A
+         :     65 3C 44 91 EA 19 39 31 33 5F 52 E9 89 A3 C4 CC
+         :     56 D9 C5 53 73 2D 57 C4 70 FB 41 AB 75 9B 65 D2
+         :     D0 44 45 38 2F CD 9C 4E 34 4A 11 28 FA 9E 11 E0
+         :     43 58 E1 92 ED 01 4B 23 23 2A 7E E2 B2 2E 23 71
+         :     7F 44 11 1E E3 35 75 39 9C 37 64 6D A9 81 3E C9
+         :     B2 12 AF E9 4E 5D C5 C2 33 0A 72 94 CC 1F 42 34
+         :     A6 D3 FB B4 F1 68 5A B8 89 2C 04 AC B1 7C D1 C1
+         :     70 D7 B0 61 1B 6A 71 76 C7 94 CC 8C 67 F5 5F C9
+         :     23 C2 AD 20 31 00 F3 65 99 18 82 C3 02 43 D7 78
+         :     13 84 3B 5E C7 C9 64 03 22 63 70 60 92 EC F0 0C
+         :     75 16 BE 64 E4 59 8C A4 22 6C 06 9B B5 E6 7E 41
+         :     75 CF 22 86 C8 DD 5C 48 8A 6C 58 61 F3 1B AA 0B
+         :     D0 26 94 70 E8 B5 51 DD 3B CD 38 C8 6C 12 F9 CD
+         :     B1 76 C7 7D C8 B6 C0 2A 70 1F 47 89 02 C8 55 3F
+         :     69 4C 0D 82 72 7B 4C 4A 5C 2C 10 41 21 2A A1 27
+         :     48 08 B8 21 11 B3 77 EC 75 21 4E 9B 19 78 F7 60
+         :     04 D4 13 9D 98 61 3F 4B 8E 98 D2 0A F7 B5 34 07
+         :     3A 50 9A 95 9B 7A 75 64 F9 B4 0C A2 18 BF 61 82
+         :     93 20 A8 50 20 17 95 4D 32 8D 7A C6 C7 69 EC 29
+         :     70 07 56 E7 B0 68 5B 34 0D 5E 11 80 59 50 4A 49
+         :     A9 A5 0A 10 19 8E B1 0A 57 84 67 8E B4 27 D7 B4
+         :     BA BB 95 52 93 3B 06 28 97 97 3E 13 18 EA F0 A0
+         :     EA C3 75 84 A6 54 01 B1 70 3E 04 2A CC D8 37 53
+         :     14 83 F2 41 CA DC D1 C1 D3 78 11 9E 69 44 29 DB
+         :     19 9A C8 91 E4 C5 34 37 57 08 5B B3 AE 78 36 67
+         :     35 0C 44 58 D9 76 72 E8 61 E8 0B 1D 26 79 51 0E
+         :     A3 A6 F2 36 0C 77 A4 69 42 C7 A0 6A 55 4D 22 80
+         :     80 C8 4B 47 AE F1 4D B1 76 20 CB 16 C0 6A B3 0A
+         :     1B E4 CD A7 08 2B E9 F8 7E 9C 21 1C 46 91 63 49
+         :     A5 BA 8E AA 52 01 C7 29 4A 3C 08 85 B5 3B 65 74
+         :     52 10 88 25 EC 64 6C 90 A0 46 12 32 4E E7 D0 31
+         :     AF E5 34 31 32 CB EF 67 B6 EF B1 A5 EC 28 09 B7
+         :     73 53 8C E7 7B 3D 8B 04 EB 0B 3C 22 56 01 1E 4C
+         :     71 6C 19 A8 BA 07 52 BF 71 49 21 17 64 9F 06 15
+         :     C3 29 0F C2 9A 46 FD E4 BD 52 DB 92 86 D6 03 38
+         :     82 44 25 9C 15 A7 AC 2B 64 0A 60 CC 03 37 6A 58
+         :     41 A3 FB 8A 47 35 68 FA 9B 1A 26 72 15 F3 4C 01
+         :     69 7B 0F 0E 62 71 75 D7 21 05 B7 70 7C 29 B9 E6
+         :     14 BD C3 3A 6F 6C 81 8A 95 37 0B 42 78 82 D7 B4
+         :     76 79 6A 9E C6 EB 99 32 74 CD 9B 23 91 A8 2B A4
+         :     5E 33 93 D2 E9 AE 97 21 CA 9D 6C 1B 98 8B 58 27
+         :     71 3F 90 A6 58 5D E9 43 35 28 C0 2B 03 CE 10 BB
+         :     5F 72 01 38 D0 FB B4 C3 0C 12 66 B9 18 E5 29 25
+         :     DF E1 7B 37 F9 5D 22 BC A5 4F 47 59 19 AC 85 90
+         :     98 C0 F0 D0 8A C5 87 5E F2 9B 56 FD 14 1E 6E F1
+         :     5F 70 0A 0B 66 F3 95 95 C5 88 17 73 73 C4 66 9B
+         :     21 BC 07 1E 4C 3A A5 F0 B4 A3 1B 62 58 F3 5D A2
+         :     4A C3 CD 29 C7 F2 09 24 10 C5 07 83 55 B1 38 FB
+         :     53 A6 B9 AE 6E 0B 9C 08 24 3E 7B AA 45 C4 73 76
+         :     EB 8C 7F 13 D4 CF 51 AA 73 6F A3 15 40 C9 24 1F
+         :     37 0D A5 44 BF 9F 9C 28 D9 A5 7E 2F 2A 7C A9 5A
+         :     4E 4B 46 6E 64 1A B3 BC C7 6A DF 11 39 D5 67 A6
+         :     F1 2B 52 F3 A6 5E 7E C0 AA E2 6B CA A8 C5 58 33
+         :     B0 4E 59 99 8E BC 9A 19 30 FB B6 D2 23 3C 53 D2
+         :     C1 F8 B9 51 8E 3C 2D E7 3A 19 DE E6 B3 80 A5 B3
+         :     29 71 CF 64 E1 29 FD 6C 1F A6 E7 5D 4A 23 45 01
+         :     E9 66 DD 3A 54 0A F5 C8 F4 F3 4A 6B 4A 25 3E E2
+         :     84 92 56 6D 5E 67 C6 F5 58 55 FC B0 50 6F B0 6C
+         :     15 67 44 D9 A0 3A 31 A2 6F A9 4C AD 14 F1 57 B7
+         :     F3 03 D0 7A 69 C7 73 76 8F CB 4D 07 9C 09 05 97
+         :     03 A0 C3 A9 4D E4 B9 9E A3 A2 F1 65 83 D0 F9 17
+         :     0A 39 50 DB 07 B4 F0 BC 30 80 29 27 F9 F7 96 1B
+         :     62 59 89 26 36 A9 50 2A 27 05 30 36 37 79 9D D3
+         :     44 DA 45 1C 1C F7 BF 67 84 0C EB 30 79 AB 8C 6B
+         :     8C 19 27 F6 40 53 C6 12 45 0C 45 C9 E6 03 BC 16
+         :     66 6E 59 6B 34 71 E1 03 B6 F1 54 47 42 4D 17 02
+         :     20 48 11 1F FB D3 7E 1C 67 0F 64 F1 4B 8A 7B 32
+         :     B9 4C 1A 49 B4 5D D2 FC 38 CD 52 89 D9 10 AD 63
+         :     60 2C F5 E1 30 42 C6 4A C6 79 7B 89 FB 55 1A D0
+         :     8E 05 A9 2D 20 0C CC B7 E7 12 EF 23 C9 31 2C B3
+         :     50 F0 29 AB 53 7E 28 73 47 FD 30 75 AC 10 90 6A
+         :     78 3F 1C 6C 07 CC B8 8F 41 22 8C 4B E1 C6 40 F7
+         :     90 B5 C3 A5 D5 D3 CA 79 24 95 D7 4B C4 61 56 26
+         :     58 C0 7A C6 00 27 6B 92 4A B5 BC 9B E1 F0 49 4C
+         :     B7 6F 82 F4 60 A7 48 09 72 66 33 81 E1 69 99 60
+         :     61 D7 99 85 9E C5 4D 4F 5C A5 C4 11 C0 1D B1 59
+         :     7B 16 59 77 66 9D E1 3A 92 8A 34 AF BA C2 58 FE
+         :     A8 C4 76 42 39 C9 42 1D C3 11 9B F5 B4 76 99 20
+         :     69 78 32 7B 1C 53 45 EF 74 6A 79 83 84 1F 05 6E
+         :     25 34 10 0A B2 4D 4E 9A BB D0 B1 7C 6A 95 BD 4C
+         :     3C 0E 40 F6 9E 16 12 AC EE B2 8B 99 08 6C 95 11
+         :     6E 72 04 27 38 93 39 0B F4 6B 89 9B 36 28 6B 0E
+         :     BF 19 47 BB 98 84 F7 32 CA 27 DA 82 B1 9B 5D C0
+         :     CC 7F 88 85 71 49 10 88 8B 23 10 C4 F9 31 9D 41
+         :     0B 34 E6 43 3B 90 03 E2 17 6B B9 95 25 74 56 10
+         :     6E 89 52 16 3B 8B A5 92 53 0C C5 AA 0A EB 43 AD
+         :     39 8F E9 E9 7B AA 52 3D 7A 44 31 67 7C 3D 3A F0
+         :     71 9E 47 5D B8 5C A9 5A F5 08 9B EA BE B0 5B 2F
+         :     AA B4 89 6B A6 0F 81 C8 84 72 A5 7B 46 A8 28 82
+         :     6A 0C DF B4 46 F8 18 91 82 D2 BF 5E AC 4E C1 CC
+         :     5D EA F5 99 C8 A1 3E 48 23 54 06 D1 7F FD DC 83
+         :     44 B6 C6 69 84 A8 68 AA 92 FA 02 22 7A 08 69 50
+         :     EB 0C 87 01 ED 58 DC 62 87 76 B9 83 88 2E 11 75
+         :   }
 ~~~
 
 The following example, in addition to encoding the ML-KEM-768 private key,

--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -540,6 +540,9 @@ key in the previous section.
        :     EB D1 ED E0 B8 1C 3B C5 9A 06 5A 1B 6D 63 B2 6C
        :   }
 ~~~
+<aside markdown="block">
+NOTE: The padding byte of the DER-encoded BIT STRING is not displayed in the pretty print above.
+</aside>
 
 The following is the ML-KEM-768 public key corresponding to the private
 key in the previous section.

--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -750,6 +750,9 @@ key in the previous section.
          :     EB 0C 87 01 ED 58 DC 62 87 76 B9 83 88 2E 11 75
          :   }
 ~~~
+<aside markdown="block">
+NOTE: The padding byte of the DER-encoded BIT STRING is not displayed in the pretty print above.
+</aside>
 
 The following example, in addition to encoding the ML-KEM-768 private key,
 has an attribute included as well as the public key:

--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -633,6 +633,9 @@ key in the previous section.
          :     1E A8 93 C3 E2 CB 32 DA 8B C3 42 FA 4D EA 05 78
          :   }
 ~~~
+<aside markdown="block">
+NOTE: The padding byte of the DER-encoded BIT STRING is not displayed in the pretty print above.
+</aside>
 
 The following is the ML-KEM-1024 public key corresponding to the private
 key in the previous section.


### PR DESCRIPTION
A line was missing from the MLKEM-512 key.
The leading 00 should not have been printed as that's part of the BIT STRING.
Used dumpasn1 tool (Sean had hand jammed it before).