### PR TITLE
Improve clarity on seed used for test vector generation

### DIFF
--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -531,7 +531,7 @@ all derived from the same 64-byte seed:
 
 For each security level, we show the seed-only format (using a 
 context-specific `[0]` primitive tag with an implicit encoding of
- `OCTET STRING`), the expanded format, and both formats together.
+`OCTET STRING`), the expanded format, and both formats together.
 
 NOTE: All examples use the same seed value, showing how the same seed
 produces different expanded private keys for each security level.

--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -521,15 +521,17 @@ certificates, and inconsistent seed and expanded private keys.
 
 The following examples show ML-KEM private keys in different formats,
 all derived from the same 64-byte seed:
+
 ~~~
 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f
 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f
 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f
 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f
 ~~~
+
 (represented compactly as "000102...3e3f").
 
-For each security level, we show the seed-only format (using a 
+For each security level, we show the seed-only format (using a
 context-specific `[0]` primitive tag with an implicit encoding of
 `OCTET STRING`), the expanded format, and both formats together.
 

--- a/draft-ietf-lamps-kyber-certificates.md
+++ b/draft-ietf-lamps-kyber-certificates.md
@@ -520,10 +520,18 @@ certificates, and inconsistent seed and expanded private keys.
 ## Example Private Keys {#example-private}
 
 The following examples show ML-KEM private keys in different formats,
-all derived from the same seed `000102...1e1f`. For each security level,
-we show the seed-only format (using a context-specific `[0]` primitive
-tag with an implicit encoding of `OCTET STRING`), the expanded format,
-and both formats together.
+all derived from the same 64-byte seed:
+~~~
+00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f
+10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f
+20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f
+30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f
+~~~
+(represented compactly as "000102...3e3f").
+
+For each security level, we show the seed-only format (using a 
+context-specific `[0]` primitive tag with an implicit encoding of
+ `OCTET STRING`), the expanded format, and both formats together.
 
 NOTE: All examples use the same seed value, showing how the same seed
 produces different expanded private keys for each security level.


### PR DESCRIPTION
Seed was incorrectly described as "000102...1f" which would be 32 bytes, not the 64 required for ML-KEM. This is corrected, and the clarity of generating the seed in general is improved from "000102...3f".